### PR TITLE
Resolve issues that modified state during view update

### DIFF
--- a/TreasureHunt/Model/LocationProvider.swift
+++ b/TreasureHunt/Model/LocationProvider.swift
@@ -22,7 +22,7 @@ class LocationProvider: NSObject, ObservableObject {
   @Published var distance: Double = 0
   @Published var wrongAuthorization: Bool = false
   @Published var reachedStation: Bool = false
-  @Published var region: MKCoordinateRegion = MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: 0, longitude: 0), latitudinalMeters: 1000, longitudinalMeters: 1000)
+  var region: MKCoordinateRegion = MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: 0, longitude: 0), latitudinalMeters: 1000, longitudinalMeters: 1000)
   private var cancellables = Set<AnyCancellable>()
   
 //  var address: String? = nil {

--- a/TreasureHunt/Model/StationsStore.swift
+++ b/TreasureHunt/Model/StationsStore.swift
@@ -8,7 +8,7 @@ class StationsStore: ObservableObject {
 
   var index: Int = -1
 
-  var stations: [Station] {
+  @Published var stations: [Station] {
     didSet {
       do {
         let data = try JSONEncoder().encode(stations)

--- a/TreasureHunt/Search/ContentView.swift
+++ b/TreasureHunt/Search/ContentView.swift
@@ -9,7 +9,7 @@ import MapKit
 struct ContentView: View {
 
   @EnvironmentObject private var locationProvider: LocationProvider
-  @State var stationsStore = StationsStore()
+  @StateObject var stationsStore = StationsStore()
   @State var name: String = ""
   @State var showInput = false
   @State var showList = false

--- a/TreasureHunt/TreasureHuntApp.swift
+++ b/TreasureHunt/TreasureHuntApp.swift
@@ -6,10 +6,12 @@ import SwiftUI
 
 @main
 struct TreasureHuntApp: App {
+  @StateObject private var locationProvider = LocationProvider()
+    
   var body: some Scene {
     WindowGroup {
       ContentView()
-        .environmentObject(LocationProvider())
+        .environmentObject(locationProvider)
     }
   }
 }


### PR DESCRIPTION
By storing the LocationProvider in a StateObject before injecting it as an EnvironmentObject, and by not publishing changes to the region property that is bound to the view, we no longer modify state during view updates. Xcode warnings resolved.